### PR TITLE
build: name executable wraith

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) !void {
     const resources = try buildpkg.GhosttyResources.init(b, &config);
 
     const exe = b.addExecutable(.{
-        .name = "ghostty-wayland",
+        .name = "wraith",
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "ghostty-wayland",
+    .name = "wraith",
 
     .version = "0.0.0",
 

--- a/dist/linux/app.desktop
+++ b/dist/linux/app.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Ghostty
+Name=Wraith
 Type=Application
 Comment=A terminal emulator
-Exec=ghostty
+Exec=wraith
 Icon=com.mitchellh.ghostty
 Categories=System;TerminalEmulator;
 Keywords=terminal;tty;pty;
@@ -19,4 +19,4 @@ X-TerminalArgHold=--wait-after-command
 
 [Desktop Action new-window]
 Name=New Window
-Exec=ghostty
+Exec=wraith


### PR DESCRIPTION
And other ghostty-wayland -> wraith changes.

Note: This doesn't fix the Resources install being named as
"com.mitchellh.ghostty". We have to fix that upstream, but at least one
can rename the file manually...
